### PR TITLE
micro3d: Fix for bmp files with invalid raster offset

### DIFF
--- a/app/src/main/java/ru/woesss/j2me/micro3d/Loader.java
+++ b/app/src/main/java/ru/woesss/j2me/micro3d/Loader.java
@@ -298,6 +298,7 @@ class Loader {
 
 		int width;
 		int height;
+		int numColors;
 		boolean reversed;
 		if (dibHeaderSize == BMP_VERSION_CORE) {
 			width = loader.readUShort();
@@ -307,6 +308,7 @@ class Loader {
 			if (bpp != 8) {
 				throw new RuntimeException("Unsupported BMP format: bpp = " + bpp);
 			}
+			numColors = 256;
 			reversed = true;
 		} else if (dibHeaderSize == BMP_VERSION_3) {
 			width = loader.readInt();
@@ -327,13 +329,16 @@ class Loader {
 			if (compression != 0) {
 				throw new RuntimeException("Unsupported BMP format: compression = " + compression);
 			}
-			loader.skip(20);
+			loader.skip(12);
+			numColors = loader.readInt();
+			if(numColors == 0) numColors = 256;
+			loader.skip(4);
 		} else {
 			throw new RuntimeException("Unsupported BMP version = " + dibHeaderSize);
 		}
 
 		int paletteOffset = BMP_FILE_HEADER_SIZE + dibHeaderSize;
-		if(rasterOffset < paletteOffset + 256 * 4) rasterOffset = paletteOffset + 256 * 4;
+		if(rasterOffset < paletteOffset + numColors * 4) rasterOffset = paletteOffset + numColors * 4;
 
 		TextureData textureData = new TextureData(width, height);
 		ByteBuffer raster = textureData.getRaster();

--- a/app/src/main/java/ru/woesss/j2me/micro3d/Loader.java
+++ b/app/src/main/java/ru/woesss/j2me/micro3d/Loader.java
@@ -333,6 +333,7 @@ class Loader {
 		}
 
 		int paletteOffset = BMP_FILE_HEADER_SIZE + dibHeaderSize;
+		if(rasterOffset < paletteOffset + 256 * 4) rasterOffset = paletteOffset + 256 * 4;
 
 		TextureData textureData = new TextureData(width, height);
 		ByteBuffer raster = textureData.getRaster();


### PR DESCRIPTION
Fix for SE version of Dakar Rally 2010 and 2009. Both games use bmp files with invalid raster offset pointing to palette data instead of pixel data, resulting in visible texture seams on level geometry and asymmetry on cars.